### PR TITLE
fix: rewrite oversized DNR regex to stay under Chrome 2KB limit

### DIFF
--- a/adb-filters/default-pie-custom.json
+++ b/adb-filters/default-pie-custom.json
@@ -4794,7 +4794,7 @@
       "type": "block"
     },
     "condition": {
-      "regexFilter": "^https://[a-z]+(\\.[a-z]+)+/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{32}\\.js$",
+      "regexFilter": "^https://[a-z.]+/[a-f0-9]+/[a-f0-9]+/[a-f0-9]+\\.js$",
       "isUrlFilterCaseSensitive": true,
       "initiatorDomains": ["streamex.sh", "cinemaos.tech", "xpass.top", "videasy.net"],
       "resourceTypes": ["script"]

--- a/adb-filters/filter-versions.json
+++ b/adb-filters/filter-versions.json
@@ -1,6 +1,6 @@
 {
-  "pieFilterVersion": 330,
+  "pieFilterVersion": 331,
   "ublockVersion": 12,
   "pieCookiesVersion": 1,
-  "declarativeVersion": 55
+  "declarativeVersion": 56
 }


### PR DESCRIPTION
## Problem

Chrome rejected DNR rule `1778010800` at compile time:

> Rule with id 1778010800 was skipped as the "regexFilter" value exceeded the 2KB memory limit when compiled.

The old regex blew up RE2's compiled automaton via the nested group quantifier `(\.[a-z]+)+` combined with counted repetitions `{2}/{2}/{32}`:

```
^https://[a-z]+(\.[a-z]+)+/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{32}\.js$
```

## Fix

```
^https://[a-z.]+/[a-f0-9]+/[a-f0-9]+/[a-f0-9]+\.js$
```

Same intent — a lowercase dotted host with three hex path segments ending in `.js`, scoped to the existing `initiatorDomains` (`streamex.sh`, `cinemaos.tech`, `xpass.top`, `videasy.net`) — without the compile-cost drivers. Legit filenames like `main.js` still won't match since `[a-f0-9]` excludes most letters.

## Version bumps

- `pieFilterVersion` 330 → 331 (required on every rule update; drives the `v331` tag + client refetch)
- `declarativeVersion` 55 → 56 (informational; DNR ruleset changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)